### PR TITLE
PhotoLibraryObserver refactor

### DIFF
--- a/Flowify.xcodeproj/project.pbxproj
+++ b/Flowify.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		598A29112C9F8F0800D9FFB0 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598A29102C9F8EFA00D9FFB0 /* CardView.swift */; };
 		59CAC5532C83E0E400977E6D /* ScreenshotHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CAC5522C83E0E400977E6D /* ScreenshotHandler.swift */; };
 		59CAC5552C83E2C600977E6D /* FormPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CAC5542C83E2C600977E6D /* FormPresenter.swift */; };
+		59D074272CE510020097F260 /* AlbumManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D074262CE50FFD0097F260 /* AlbumManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		598A29102C9F8EFA00D9FFB0 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		59CAC5522C83E0E400977E6D /* ScreenshotHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotHandler.swift; sourceTree = "<group>"; };
 		59CAC5542C83E2C600977E6D /* FormPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormPresenter.swift; sourceTree = "<group>"; };
+		59D074262CE50FFD0097F260 /* AlbumManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +127,7 @@
 		597B0C4D2CA4F0C900F565CA /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				59D074262CE50FFD0097F260 /* AlbumManager.swift */,
 				597B0C552CAE32FC00F565CA /* DataModel.swift */,
 				59CAC5522C83E0E400977E6D /* ScreenshotHandler.swift */,
 			);
@@ -307,6 +310,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				598A290D2C9EBD5800D9FFB0 /* ImagePicker.swift in Sources */,
+				59D074272CE510020097F260 /* AlbumManager.swift in Sources */,
 				598A29112C9F8F0800D9FFB0 /* CardView.swift in Sources */,
 				5964EFB92C431FD200C2D8DA /* FormViewController.swift in Sources */,
 				597B0C542CAE30B400F565CA /* PhotoLibraryObserver.swift in Sources */,

--- a/Flowify/Model/AlbumManager.swift
+++ b/Flowify/Model/AlbumManager.swift
@@ -1,0 +1,8 @@
+//
+//  AlbumManager.swift
+//  Flowify
+//
+//  Created by jambo on 11/13/24.
+//
+
+class AlbumManager {}

--- a/Flowify/Model/ScreenshotHandler.swift
+++ b/Flowify/Model/ScreenshotHandler.swift
@@ -9,97 +9,237 @@ import Foundation
 import Photos
 import UIKit
 
-class ScreenshotHandler {
-    // FormData; will most likely move to a different class
+class ScreenshotHandler: NSObject {
     private(set) var formData: [String: String] = [:]
     private let imageMerger = ImageMerger()
-
-    func updateData(formData: [String: String]) {
-        let data = formData
-        self.formData = data
+    private var processedAssets = Set<String>()
+    
+    override init() {
+        super.init()
+        loadProcessedAssets()  // Load previously processed assets
     }
-
+    
+    func updateData(formData: [String: String]) {
+        self.formData = formData
+    }
+    
     private func dictionaryLookUp(forKey key: String, in dictionary: [String: String]) -> String {
         return dictionary[key] ?? ""
     }
-
+    
     func albumCreation(completion: @escaping (Bool, Error?) -> Void) {
         let nameData = dictionaryLookUp(forKey: "name", in: formData)
+        guard !nameData.isEmpty else {
+            completion(false, NSError(domain: "ScreenshotHandler", code: -1, userInfo: [NSLocalizedDescriptionKey: "Album name is empty"]))
+            return
+        }
+        
         PHPhotoLibrary.shared().performChanges({
             let options = PHFetchOptions()
             options.predicate = NSPredicate(format: "title = %@", nameData)
             let existingAlbum = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: options).firstObject
-
             if existingAlbum == nil {
-                // Creates new album
+                print("Creating new album: \(nameData)")
                 _ = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: nameData)
+            } else {
+                print("Album \(nameData) already exists")
             }
         }) { success, error in
             completion(success, error)
         }
     }
-
+    
     func processScreenshots(assets: [PHAsset]) {
-        for asset in assets {
-            processScreenshot(asset: asset)
+        let nameData = dictionaryLookUp(forKey: "name", in: formData)
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.predicate = NSPredicate(format: "title = %@", nameData)
+        
+        guard let album = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions).firstObject else {
+            print("Target album not found")
+            return
         }
-    }
-
-    private func processScreenshot(asset: PHAsset) {
-        let options = PHImageRequestOptions()
-        options.isSynchronous = true
-        PHImageManager.default().requestImageData(for: asset, options: options) { data, _, _, _ in
-            guard let imageData = data else {
-                print("Failed to get image data for asset: \(asset)")
-                return
+        
+        // First, get all assets in the album for merging
+        let albumAssets = PHAsset.fetchAssets(in: album, options: nil)
+        loadImagesFromAlbum(albumAssets) { [weak self] images in
+            if !images.isEmpty {
+                // This will trigger merging only after processing all assets
+                print("Images loaded from album, waiting to merge.")
             }
-
-            self.copyImageIntoAlbum(imageData: imageData, originalAsset: asset)
         }
+        
+        // Process new assets
+        processNewAssets(assets, to: album)
     }
-
-    private func copyImageIntoAlbum(imageData: Data, originalAsset _: PHAsset) {
-        PHPhotoLibrary.shared().performChanges({
-            // Fetch the album where we want to save the new image
-            let nameData = self.dictionaryLookUp(forKey: "name", in: self.formData)
-            let fetchOptions = PHFetchOptions()
-            fetchOptions.predicate = NSPredicate(format: "title = %@", nameData)
-            let album = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions).firstObject
-
-            // Create the new image asset in the album
-            if let album = album {
-                let creationRequest = PHAssetCreationRequest.creationRequestForAsset(from: UIImage(data: imageData)!)
-                let assetPlaceholder = creationRequest.placeholderForCreatedAsset
-                let albumChangeRequest = PHAssetCollectionChangeRequest(for: album)
-                albumChangeRequest?.addAssets([assetPlaceholder!] as NSArray)
+    
+    func mergeImagesAfterProcessing(assets: [PHAsset]) {
+        // Once new assets have been processed, perform image merging
+        let nameData = dictionaryLookUp(forKey: "name", in: formData)
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.predicate = NSPredicate(format: "title = %@", nameData)
+        
+        guard let album = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions).firstObject else {
+            print("Target album not found for merging.")
+            return
+        }
+        
+        // Load images for merging
+        let albumAssets = PHAsset.fetchAssets(in: album, options: nil)
+        loadImagesFromAlbum(albumAssets) { [weak self] images in
+            if !images.isEmpty {
+                self?.mergeAndSaveImages(images: images) { success, error in
+                    if let error = error {
+                        print("Error merging images: \(error.localizedDescription)")
+                    } else {
+                        print("Images merged successfully")
+                    }
+                }
             } else {
-                print("Album not found")
+                print("No images found to merge.")
             }
+        }
+    }
+    
+    private func processNewAssets(_ assets: [PHAsset], to album: PHAssetCollection) {
+        let albumAssets = PHAsset.fetchAssets(in: album, options: nil)
+        var existingAssetIds = Set<String>()
+        albumAssets.enumerateObjects { asset, _, _ in
+            existingAssetIds.insert(asset.localIdentifier)
+        }
+        
+        let newAssets = assets.filter { asset in
+            let isNew = !existingAssetIds.contains(asset.localIdentifier) && !processedAssets.contains(asset.localIdentifier)
+            if isNew {
+                print("New asset to process: \(asset.localIdentifier)")
+            }
+            return isNew
+        }
+        
+        if newAssets.isEmpty {
+            print("No new assets to process.")
+        } else {
+            print("Processing \(newAssets.count) new assets.")
+            processBatch(assets: newAssets, to: album)
+        }
+    }
+    
+    private func loadImagesFromAlbum(_ assets: PHFetchResult<PHAsset>, completion: @escaping ([UIImage]) -> Void) {
+        var images: [UIImage] = []
+        let group = DispatchGroup()
+        
+        assets.enumerateObjects { asset, _, _ in
+            group.enter()
+            let options = PHImageRequestOptions()
+            options.deliveryMode = .highQualityFormat
+            options.isSynchronous = false
+            
+            PHImageManager.default().requestImage(
+                for: asset,
+                targetSize: PHImageManagerMaximumSize,
+                contentMode: .default,
+                options: options
+            ) { image, info in
+                if let image = image {
+                    images.append(image)
+                }
+                group.leave()
+            }
+        }
+        
+        group.notify(queue: .main) {
+            completion(images)
+        }
+    }
+    
+    private func processBatch(assets: [PHAsset], to album: PHAssetCollection) {
+        let group = DispatchGroup()
+        var processedImages: [(PHAsset, Data)] = []
+        
+        for asset in assets {
+            group.enter()
+            requestImageData(for: asset) { imageData in
+                if let imageData = imageData {
+                    processedImages.append((asset, imageData))
+                }
+                group.leave()
+            }
+        }
+        
+        group.notify(queue: .main) {
+            self.copyImagesIntoAlbum(processedImages: processedImages, album: album)
+        }
+    }
+    
+    private func requestImageData(for asset: PHAsset, completion: @escaping (Data?) -> Void) {
+        let options = PHImageRequestOptions()
+        options.isNetworkAccessAllowed = true
+        options.deliveryMode = .highQualityFormat
+        options.isSynchronous = false
+        
+        PHImageManager.default().requestImageData(for: asset, options: options) { data, _, _, _ in
+            completion(data)
+        }
+    }
+    
+    private func copyImagesIntoAlbum(processedImages: [(PHAsset, Data)], album: PHAssetCollection) {
+        guard !processedImages.isEmpty else { return }
+        
+        PHPhotoLibrary.shared().performChanges({
+            let albumChangeRequest = PHAssetCollectionChangeRequest(for: album)
+            var assetPlaceholders: [PHObjectPlaceholder] = []
+            
+            for (asset, imageData) in processedImages {
+                if let image = UIImage(data: imageData) {
+                    let creationRequest = PHAssetCreationRequest.creationRequestForAsset(from: image)
+                    if let placeholder = creationRequest.placeholderForCreatedAsset {
+                        assetPlaceholders.append(placeholder)
+                        self.processedAssets.insert(asset.localIdentifier)
+                    }
+                }
+            }
+            
+            albumChangeRequest?.addAssets(assetPlaceholders as NSArray)
+            
         }) { success, error in
             if let error = error {
-                print("Error saving image: \(error.localizedDescription)")
+                print("Error saving images: \(error.localizedDescription)")
             } else if success {
-                print("Image successfully saved to album.")
+                print("Successfully saved \(processedImages.count) images to album")
             }
         }
     }
-
-    // MARK: ImageSavedDelegate
+    
+    // MARK: Image Merging
     func mergeAndSaveImages(images: [UIImage], completion: @escaping (Bool, Error?) -> Void) {
         guard let mergedImage = imageMerger.mergeImages(images: images) else {
             completion(false, nil)
             return
         }
-
-        // Save the merged image to the photo library directly
         UIImageWriteToSavedPhotosAlbum(mergedImage, self, #selector(self.image(_:didFinishSavingWithError:contextInfo:)), nil)
+        completion(true, nil)
     }
-
+    
     @objc private func image(_ image: UIImage, didFinishSavingWithError error: Error?, contextInfo: UnsafeRawPointer) {
         if let error = error {
-            print("Error saving image: \(error.localizedDescription)")
+            print("Error saving merged image: \(error.localizedDescription)")
         } else {
-            print("Image saved successfully!")
+            print("Merged image saved successfully!")
         }
+    }
+    
+    // MARK: - Persistence
+    private func loadProcessedAssets() {
+        if let savedAssets = UserDefaults.standard.array(forKey: "ProcessedAssets") as? [String] {
+            processedAssets = Set(savedAssets)
+        }
+    }
+    
+    private func saveProcessedAssets() {
+        UserDefaults.standard.set(Array(processedAssets), forKey: "ProcessedAssets")
+    }
+    
+    func addProcessedAsset(_ asset: PHAsset) {
+        processedAssets.insert(asset.localIdentifier)
+        saveProcessedAssets()  // Save to UserDefaults after each new processed asset
     }
 }

--- a/Flowify/Presenter/FormPresenter.swift
+++ b/Flowify/Presenter/FormPresenter.swift
@@ -18,7 +18,7 @@ class FormPresenter {
 
     init() {
         handler = ScreenshotHandler()
-        photoLibraryObserver = PhotoLibraryObserver()
+        photoLibraryObserver = PhotoLibraryObserver(albumName: "Dog")
     }
 
     // Completion handler to make sure the recording is starting or ending

--- a/Flowify/Presenter/PhotoLibraryObserver.swift
+++ b/Flowify/Presenter/PhotoLibraryObserver.swift
@@ -5,11 +5,9 @@
 //  Created by jambo on 10/2/24.
 //
 
-import Foundation
 import Photos
-import UIKit
 
-class PhotoLibraryObserver: NSObject {
+class PhotoLibraryObserver: NSObject, PHPhotoLibraryChangeObserver {
     private var isObserving = false
     private var screenshotHandler: ScreenshotHandler?
     private var processedAssets = Set<String>()
@@ -19,12 +17,12 @@ class PhotoLibraryObserver: NSObject {
         self.screenshotHandler = ScreenshotHandler()
         self.screenshotHandler?.updateData(formData: ["name": albumName])
     }
-    
+
     func startObserving() {
         screenshotHandler?.albumCreation { [weak self] success, error in
             if success {
                 guard !(self?.isObserving ?? true) else { return }
-                PHPhotoLibrary.shared().register(self!)
+                PHPhotoLibrary.shared().register(self!) // Register as observer
                 self?.isObserving = true
                 print("Started observing photo library changes.")
             } else if let error = error {
@@ -32,21 +30,17 @@ class PhotoLibraryObserver: NSObject {
             }
         }
     }
-    
+
     func stopObserving() {
         guard isObserving else { return }
-        PHPhotoLibrary.shared().unregisterChangeObserver(self)
+        PHPhotoLibrary.shared().unregisterChangeObserver(self) // Unregister as observer
         isObserving = false
         print("Stopped observing photo library changes.")
+        
+        // Fetch the album and its assets, then merge
+        fetchAlbumAndMergeImages()
     }
-    
-    private func isScreenshot(_ asset: PHAsset) -> Bool {
-        return asset.mediaSubtypes.contains(.photoScreenshot)  // More reliable screenshot check
-    }
-}
 
-// MARK: - PhotoLibraryObserver Extension
-extension PhotoLibraryObserver: PHPhotoLibraryChangeObserver {
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         DispatchQueue.main.async {
             print("Photo library change detected")
@@ -67,16 +61,55 @@ extension PhotoLibraryObserver: PHPhotoLibraryChangeObserver {
                 self.processedAssets.insert(asset.localIdentifier)
             }
         }
-        
+
         guard !newScreenshots.isEmpty else {
             print("No new screenshots found.")
             return
         }
-        
+
         print("New screenshots detected: \(newScreenshots.count)")
         screenshotHandler?.processScreenshots(assets: newScreenshots)
-        
-        // Merge images after processing the batch of new assets
-//        screenshotHandler?.mergeImagesAfterProcessing(assets: newScreenshots)
+    }
+    
+    private func isScreenshot(_ asset: PHAsset) -> Bool {
+        return asset.mediaSubtypes.contains(.photoScreenshot)  // More reliable screenshot check
+    }
+
+    private func fetchAlbumAndMergeImages() {
+        // Use ScreenshotHandler to fetch the album
+        screenshotHandler?.albumCreation { [weak self] success, error in
+            if success {
+                // Fetch the assets from the album
+                let nameData = self?.screenshotHandler?.dictionaryLookUp(forKey: "name", in: self?.screenshotHandler?.formData ?? [:]) ?? ""
+                let fetchOptions = PHFetchOptions()
+                fetchOptions.predicate = NSPredicate(format: "title = %@", nameData)
+                
+                // Fetch the album by title
+                guard let album = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions).firstObject else {
+                    print("Album not found for merging.")
+                    return
+                }
+
+                // Fetch assets within the album
+                let albumAssets = PHAsset.fetchAssets(in: album, options: nil)
+
+                // Load images and merge them
+                self?.screenshotHandler?.loadImagesFromAlbum(albumAssets) { images in
+                    if !images.isEmpty {
+                        self?.screenshotHandler?.mergeAndSaveImages(images: images) { success, error in
+                            if let error = error {
+                                print("Error merging images: \(error.localizedDescription)")
+                            } else {
+                                print("Images merged successfully.")
+                            }
+                        }
+                    } else {
+                        print("No images found to merge.")
+                    }
+                }
+            } else if let error = error {
+                print("Error creating album: \(error.localizedDescription)")
+            }
+        }
     }
 }

--- a/Flowify/Presenter/PhotoLibraryObserver.swift
+++ b/Flowify/Presenter/PhotoLibraryObserver.swift
@@ -5,49 +5,78 @@
 //  Created by jambo on 10/2/24.
 //
 
+import Foundation
 import Photos
+import UIKit
 
 class PhotoLibraryObserver: NSObject {
     private var isObserving = false
-    private var lastToken: Int = 0 // To keep track of the last assigned token
-
-    // Start observing photo library changes
-    func startObserving() {
-        guard !isObserving else { return }
-        PHPhotoLibrary.shared().register(self)
-        isObserving = true
-        print("Started observing photo library changes.")
+    private var screenshotHandler: ScreenshotHandler?
+    private var processedAssets = Set<String>()
+    
+    init(albumName: String) {
+        super.init()
+        self.screenshotHandler = ScreenshotHandler()
+        self.screenshotHandler?.updateData(formData: ["name": albumName])
     }
-
-    // Stop observing photo library changes
+    
+    func startObserving() {
+        screenshotHandler?.albumCreation { [weak self] success, error in
+            if success {
+                guard !(self?.isObserving ?? true) else { return }
+                PHPhotoLibrary.shared().register(self!)
+                self?.isObserving = true
+                print("Started observing photo library changes.")
+            } else if let error = error {
+                print("Failed to create/verify album: \(error.localizedDescription)")
+            }
+        }
+    }
+    
     func stopObserving() {
         guard isObserving else { return }
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
         isObserving = false
         print("Stopped observing photo library changes.")
     }
+    
+    private func isScreenshot(_ asset: PHAsset) -> Bool {
+        return asset.mediaSubtypes.contains(.photoScreenshot)  // More reliable screenshot check
+    }
 }
 
-// Conforming to the PHPhotoLibraryChangeObserver protocol
+// MARK: - PhotoLibraryObserver Extension
 extension PhotoLibraryObserver: PHPhotoLibraryChangeObserver {
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         DispatchQueue.main.async {
+            print("Photo library change detected")
             self.handlePhotoLibraryChange()
         }
     }
-
+    
     private func handlePhotoLibraryChange() {
-        // Fetch the latest images from the library
         let fetchOptions = PHFetchOptions()
         fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-
         let fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions)
-
-        // Process newly added assets
-        if fetchResult.count > 0 {
-            print("New images detected: (fetchResult.count)")
-        } else {
-            print("No new images found.")
+        
+        var newScreenshots: [PHAsset] = []
+        
+        fetchResult.enumerateObjects { asset, _, _ in
+            if !self.processedAssets.contains(asset.localIdentifier) && self.isScreenshot(asset) {
+                newScreenshots.append(asset)
+                self.processedAssets.insert(asset.localIdentifier)
+            }
         }
+        
+        guard !newScreenshots.isEmpty else {
+            print("No new screenshots found.")
+            return
+        }
+        
+        print("New screenshots detected: \(newScreenshots.count)")
+        screenshotHandler?.processScreenshots(assets: newScreenshots)
+        
+        // Merge images after processing the batch of new assets
+//        screenshotHandler?.mergeImagesAfterProcessing(assets: newScreenshots)
     }
 }


### PR DESCRIPTION
Refactored the PhotoLibraryObserver and the ScreenshotHandler classes now the app will:
- Observe singular assets and log the photo id to terminal
- Once the recording toggle is stopped the album will be fetched and be merged outside of the album

TODO:
Enforce ordering
Fix logging bug on "No new screenshots found." print
Separate responsibilities of album creation/management to a new class called AlbumManager.